### PR TITLE
Add Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+dist: bionic
+
+language: go
+
+go:
+  - 1.13.x
+
+cache:
+  directories:
+    - $GOPATH/pkg/mod
+
+env:
+  global:
+    - CGO_ENABLED=0
+
+script:
+  - go build -o ./nfproxy ./cmd/nfproxy.go


### PR DESCRIPTION
* Add .travis.yml for Travis build integration
  - Build nfproxy with Go 1.13.x on Ubuntu Bionic's Travis VM