### PR TITLE
Add bootstrap rules

### DIFF
--- a/cmd/nfproxy.go
+++ b/cmd/nfproxy.go
@@ -87,7 +87,12 @@ func main() {
 	host := os.Getenv("KUBERNETES_SERVICE_HOST")
 	port := os.Getenv("KUBERNETES_SERVICE_PORT")
 	if host != "" && port != "" {
-		if err := proxy.BootstrapRules(nfproxy, host, port); err != nil {
+		extAddr := os.Getenv("NFPROXY_IP")
+		if extAddr == "" {
+			klog.Errorf("nfproxy in \"in-cluster\" more requires env variable \"NFPROXY_IP\" to be set to nfproxy pod's IP address")
+			os.Exit(1)
+		}
+		if err := proxy.BootstrapRules(nfproxy, host, extAddr, port); err != nil {
 			klog.Errorf("nfproxy failed to add bootstrap rules with error: %+v", err)
 			os.Exit(1)
 		}

--- a/cmd/nfproxy.go
+++ b/cmd/nfproxy.go
@@ -82,8 +82,8 @@ func main() {
 
 	// Create new instance of a proxy process
 	nfproxy := proxy.NewProxy(nfti, hostname, recorder)
-	// For "in-cluster" mode a rule to reach API server must be programmed, otherwise a controller
-	// running "in-cluster" cannot reach it.
+	// For "in-cluster" mode a rule to reach API server must be programmed, otherwise
+	// the services/endpoints controller cannot reach it.
 	host := os.Getenv("KUBERNETES_SERVICE_HOST")
 	port := os.Getenv("KUBERNETES_SERVICE_PORT")
 	if host != "" && port != "" {
@@ -100,7 +100,7 @@ func main() {
 
 	controller := controller.NewController(client, nfproxy)
 	if err := controller.Run(wait.NeverStop); err != nil {
-		klog.Errorf("nfproxy failed to start controller with error: %s", err)
+		klog.Errorf("nfproxy failed to start the controller with error: %s", err)
 		os.Exit(1)
 	}
 

--- a/deployment/nfproxy.yaml
+++ b/deployment/nfproxy.yaml
@@ -101,6 +101,11 @@ spec:
             - "57.112.0.0/12"
             - --ipv6clustercidr
             - ""
+          env:
+            - name: NFPROXY_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
 metadata:
   name: nfproxy
   namespace: kube-system

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -537,7 +537,7 @@ func (p *proxy) UpdateEndpoints(epOld, epNew *v1.Endpoints) {
 
 // BootstrapRules programs rules so the controller could reach API server
 // when it runs "in-cluster" mode.
-func BootstrapRules(p Proxy, host string, port string) error {
+func BootstrapRules(p Proxy, host, extAddr string, port string) error {
 	// TODO (sbezverk) Consider adding ip address validation
 	pn, err := strconv.Atoi(port)
 	if err != nil {
@@ -573,8 +573,7 @@ func BootstrapRules(p Proxy, host string, port string) error {
 			{
 				Addresses: []v1.EndpointAddress{
 					{
-						// TODO (sbezverk) find a way to get this IP from environment
-						IP: "192.168.80.104",
+						IP: extAddr,
 					},
 				},
 				Ports: []v1.EndpointPort{


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

PR adds bootstrap rules. When proxy runs in `in-cluster` mode, the services/endpoints controller needs to access kubernetes api by its internal address, since there are no rules, it cannot access. With the bootstrap rules the controller will be able to communicate with API and start services/endpoints watchers.