### PR TITLE
Table cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/google/nftables v0.0.0-20200101160555-80a905063cf2
-	github.com/sbezverk/nftableslib v0.0.0-20200110170830-83f42f90600c
+	github.com/sbezverk/nftableslib v0.0.0-20200114150953-655f2aba1385
 	golang.org/x/sys v0.0.0-20191220220014-0732a990476f
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -424,6 +424,8 @@ github.com/sbezverk/nftableslib v0.0.0-20200103182035-d2e4311b623b h1:a+hFd6KlQe
 github.com/sbezverk/nftableslib v0.0.0-20200103182035-d2e4311b623b/go.mod h1:43B0iHiyXSEJFNI5xbcu45LRUVVsz01D4Xe7VPcJTdo=
 github.com/sbezverk/nftableslib v0.0.0-20200110170830-83f42f90600c h1:rG00jMx2UMpKzTVf8oUC26xOuBqe5uJdUBaGqYSTIJw=
 github.com/sbezverk/nftableslib v0.0.0-20200110170830-83f42f90600c/go.mod h1:43B0iHiyXSEJFNI5xbcu45LRUVVsz01D4Xe7VPcJTdo=
+github.com/sbezverk/nftableslib v0.0.0-20200114150953-655f2aba1385 h1:dwXc8lD4aAGqAVdw/U9rjFi+pU4XKebmrOl/X3del/k=
+github.com/sbezverk/nftableslib v0.0.0-20200114150953-655f2aba1385/go.mod h1:43B0iHiyXSEJFNI5xbcu45LRUVVsz01D4Xe7VPcJTdo=
 github.com/sbezverk/nftableslib/e2e/setenv v0.0.0-20191009154549-4fe065fe4e96/go.mod h1:eg/8FSK3bdB2DJRB5Cs8oIXtqYtF/KbMRwyuaZ13SG4=
 github.com/sbezverk/nftableslib/e2e/setenv v0.0.0-20191010164456-029e0d78cdb1/go.mod h1:Q7cQRSoGvFdscKripABhD9LwzMPI7nyH/W19KStrNEE=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=


### PR DESCRIPTION
Instead of flushing all nftables found on the host, delete only tables that belongs to nfproxy.