### PR TITLE
Fix panic in dual stack mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sbezverk/nfproxy
 go 1.13
 
 require (
-	github.com/google/nftables v0.0.0-20200227072857-9caf4234bf8a
+	github.com/google/nftables v0.0.0-20200306103218-21c5c5c4256e
 	github.com/sbezverk/nfproxy/pkg/endpointsgen v0.0.0-20200123132715-2f86a494a51c // indirect
 	github.com/sbezverk/nftableslib v0.0.0-20200228131025-c43f9ed7f1bf
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,8 @@ github.com/google/nftables v0.0.0-20200210101420-1c56a1906fbf h1:7LRYMcY5YBAZa9a
 github.com/google/nftables v0.0.0-20200210101420-1c56a1906fbf/go.mod h1:cfspEyr/Ap+JDIITA+N9a0ernqG0qZ4W1aqMRgDZa1g=
 github.com/google/nftables v0.0.0-20200227072857-9caf4234bf8a h1:KiLSDEQZd/Dl06pGvusG45l5nVll9ZW011Aew4/2vBs=
 github.com/google/nftables v0.0.0-20200227072857-9caf4234bf8a/go.mod h1:cfspEyr/Ap+JDIITA+N9a0ernqG0qZ4W1aqMRgDZa1g=
+github.com/google/nftables v0.0.0-20200306103218-21c5c5c4256e h1:b8NG69b0UksUGVX4lryC1UHGIOmVD6qd6MX9NwM8Nw4=
+github.com/google/nftables v0.0.0-20200306103218-21c5c5c4256e/go.mod h1:cfspEyr/Ap+JDIITA+N9a0ernqG0qZ4W1aqMRgDZa1g=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/pkg/proxy/proxy_service.go
+++ b/pkg/proxy/proxy_service.go
@@ -37,7 +37,7 @@ func (p *proxy) AddService(svc *v1.Service) {
 	if svc == nil {
 		return
 	}
-	klog.V(6).Infof("AddService for a service Spec: %+v Status: %+v", svc.Spec, svc.Status)
+	klog.V(6).Infof("AddService for a service Spec: %+v Status: %+v Address Family: %v", svc.Spec, svc.Status, *svc.Spec.IPFamily)
 	if svc.Spec.SessionAffinity == v1.ServiceAffinityClientIP {
 		stickySeconds := int(*svc.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds)
 		klog.V(5).Infof("Service %s/%s has SessionAffinity set for %d seconds", svc.Namespace, svc.Name, stickySeconds)

--- a/pkg/proxy/proxy_service.go
+++ b/pkg/proxy/proxy_service.go
@@ -37,7 +37,9 @@ func (p *proxy) AddService(svc *v1.Service) {
 	if svc == nil {
 		return
 	}
-	klog.V(6).Infof("AddService for a service Spec: %+v Status: %+v Address Family: %v", svc.Spec, svc.Status, *svc.Spec.IPFamily)
+
+	klog.V(6).Infof("AddService for a service Spec: %+v Status: %+v", svc.Spec, svc.Status)
+
 	if svc.Spec.SessionAffinity == v1.ServiceAffinityClientIP {
 		stickySeconds := int(*svc.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds)
 		klog.V(5).Infof("Service %s/%s has SessionAffinity set for %d seconds", svc.Namespace, svc.Name, stickySeconds)


### PR DESCRIPTION
There was a scenario when Service had IPv4 address family but associated endpoint ipv6. This scenario is not currently supported. For now put a protective fix not to panic but generate an error message