### PR TITLE
Use label service.kubernetes.io/service-proxy-name to select nfproxy

### DIFF
--- a/cmd/nfproxy.go
+++ b/cmd/nfproxy.go
@@ -49,10 +49,11 @@ import (
 )
 
 var (
-	kubeconfig      string
-	ipv4ClusterCIDR string
-	ipv6ClusterCIDR string
-	endpointSlice   bool
+	kubeconfig       string
+	ipv4ClusterCIDR  string
+	ipv6ClusterCIDR  string
+	serviceProxyName string
+	endpointSlice    bool
 )
 
 type epController interface {
@@ -63,6 +64,7 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file.")
 	flag.StringVar(&ipv4ClusterCIDR, "ipv4clustercidr", "", "The IPv4 CIDR range of pods in the cluster.")
 	flag.StringVar(&ipv6ClusterCIDR, "ipv6clustercidr", "", "The IPv6 CIDR range of pods in the cluster.")
+	flag.StringVar(&serviceProxyName, "service-proxy-name", "", "Let nfproxy only handle services with this label (empty = all services)")
 	flag.BoolVar(&endpointSlice, "endpointslice", false, "Enables to use EndpointSlice instead of Endpoints. Default is flase.")
 }
 

--- a/cmd/nfproxy.go
+++ b/cmd/nfproxy.go
@@ -148,7 +148,15 @@ func main() {
 		klog.Fatalf("Failed to create Requirement for noHeadlessEndpoints: %s", err.Error())
 	}
 	labelSelector := labels.NewSelector()
-	labelSelector = labelSelector.Add(*noHeadlessEndpoints)
+	if serviceProxyName == "" {
+		labelSelector = labelSelector.Add(*noHeadlessEndpoints)
+	} else {
+		proxySelector, err := labels.NewRequirement("service.kubernetes.io/service-proxy-name", selection.DoubleEquals, []string{serviceProxyName})
+		if err != nil {
+			klog.Fatalf("Failed to create Requirement for noHeadlessEndpoints: %s", err.Error())
+		}
+		labelSelector = labelSelector.Add(*noHeadlessEndpoints, *proxySelector)
+	}
 
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(client, time.Minute*10,
 		kubeinformers.WithTweakListOptions(func(options *metav1.ListOptions) {


### PR DESCRIPTION
Implements #49 

- [x] Use `NewSharedInformerFactoryWithOptions()` and filter out headless services
- [x] Simple regression test
- [x] Add a `--service-proxy-name` option
- [x] Filter services on `service.kubernetes.io/service-proxy-name` if the option is given
- [x] Test that `nfproxy` and `kube-proxy` can be both be started and `nfproxy` keep away from services without the label
- [x] Create a service with the label and test that it works
- [ ] Test that services with and without the label can co-exist without messing up
- [ ] Update documentation
