### PR TITLE
Document label-select deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ This command will compile nfproxy binary and then will build a docker container 
 
 ## Deployment
 
+`Nfproxy` can be deployed in two ways;
+
+* Replace the Kubernetes `kube-proxy`. All services will be served by `nfproxy`
+
+* Install `nfproxy` and select which services that shall be served by `nfproxy` using the label `service.kubernetes.io/service-proxy-name: nfproxy`. The K8s installation (kube-proxy) is not altered.
+
+
+
+### Replace kube-proxy
+
+
 1. Find a way to save kube-proxy's daemonset yaml, once you tired of playing with nfproxy,
 this yaml will allow you to restore the default kube-proxy functionality.
 
@@ -97,6 +108,32 @@ If nfproxy started successfully, pod's log will contain messages about discovere
 ```
 kubectl delete -f ./deployment/nfproxy.yaml
 ```
+
+### Select nfproxy with a label
+
+`Nfproxy` is installed as any application and will only be used for services that explicitly request it. Example;
+
+```
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  labels:
+    service.kubernetes.io/service-proxy-name: nfproxy
+spec:
+  ipFamily: IPv4
+  selector:
+    app: some-http-server
+  ports:
+  - port: 80
+  type: LoadBalancer
+```
+
+The `service.kubernetes.io/service-proxy-name` will make the `kube-proxy` ignore the service. Instead `nfproxy` watches services with this label an will setup nftables for load balancing.
+
+Deployment follows the same steps as when `kube-proxy` is replaced minus the removal of `kube-proxy` (obviously). Perform the steps from **3** above but use `./deployment/nfproxy-label-select.yaml` instead.
+
+
 
 ## Status
 

--- a/deployment/nfproxy-label-select.yaml
+++ b/deployment/nfproxy-label-select.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfproxy
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nfproxy
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - services
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - patch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - list
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfproxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nfproxy
+subjects:
+  - kind: ServiceAccount
+    name: nfproxy
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+spec:
+  selector:
+    matchLabels:
+      app: nfproxy
+  template:
+    metadata:
+      labels:
+        app: nfproxy
+    spec:
+      serviceAccountName: nfproxy
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - operator: Exists
+      initContainers:
+        - name: filter-forward-policy
+          image: docker.io/sbezverk/nfproxy-iptables-fixup:0.0.0
+          securityContext:
+            privileged: true
+      containers:
+        - name: nfproxy
+          image: docker.io/sbezverk/nfproxy-debug:0.0.0
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          args:
+            - --ipv4clustercidr
+            - "57.48.0.0/12"
+            - --ipv6clustercidr
+            - ""
+            - --v
+            - "5"
+            - --service-proxy-name
+            - "nfproxy"
+          env:
+            - name: API_PUBLIC_ENDPOINT
+              value: "{API Server public endpoint in format http://ipaddress:port for insecure or https://ipaddress:port for  }"
+metadata:
+  name: nfproxy
+  namespace: kube-system


### PR DESCRIPTION
Pre-view at; https://github.com/Nordix/nfproxy/tree/label-select-doc

* I have not tested the `nfproxy-label-select.yaml` since I don't install `nfproxy` as a pod myself but start it from a script.


* There is an init-container;
```
      initContainers:
        - name: filter-forward-policy
          image: docker.io/sbezverk/nfproxy-iptables-fixup:0.0.0
          securityContext:
            privileged: true
```
Is it still needed when kube-proxy is left intact?
